### PR TITLE
Remove unused public constant SSTATUS_VS

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -75,7 +75,6 @@ pub const SSTATUS_SIE: u64 = 0x00000002;
 //pub const SSTATUS_UPIE: u64 = 0x00000010;
 pub const SSTATUS_SPIE: u64 = 0x00000020;
 pub const SSTATUS_SPP: u64 = 0x00000100;
-pub const SSTATUS_VS: u64 = 0x00000600;
 pub const SSTATUS_FS: u64 = 0x00006000;
 pub const SSTATUS_XS: u64 = 0x00018000;
 pub const SSTATUS_SUM: u64 = 0x00040000;


### PR DESCRIPTION
Hello, as a beginner at the RISC-V emulator, I really learn a lot from this project. So I would like to thank you for this first :)

When I read the codes, I found that there's a mask named `SSTATUS_VS` which would never be used. According to what I read from the RISC-V instruction set manual, I didn't see any field in `sstatus` named `VS`. Also, the mask `0x00000600` is marked to `WPRI` on the manual. So I think `SSTATUS_VS`  won't be used in the future, too. We are able to remove this mask.

![image](https://user-images.githubusercontent.com/30153990/106490865-38562e00-64f1-11eb-8c43-dd5f3319f4b1.png)


