### PR TITLE
Fix wrong implementation of C.JR

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1206,7 +1206,7 @@ impl Cpu {
 
                                 let rs1 = (inst >> 7) & 0x1f;
                                 if rs1 != 0 {
-                                    self.pc = self.xregs.read(rs1).wrapping_sub(2);
+                                    self.pc = self.xregs.read(rs1);
                                 }
                             }
                             (0, _) => {


### PR DESCRIPTION
According to the spec of C.JR:
> C.JR (jump register) performs an unconditional control transfer to the address in register rs1.

If I don't get it wrong, I think we just need to write the absolute address in `rs1` to `pc`?  