### PR TITLE
feat: expose ROM so it can be changed externally

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -51,7 +51,7 @@ pub struct Bus {
     pub uart: Uart,
     pub virtio: Virtio,
     dram: Dram,
-    rom: Rom,
+    pub rom: Rom,
 }
 
 impl Bus {

--- a/src/rom.rs
+++ b/src/rom.rs
@@ -159,6 +159,10 @@ impl Rom {
         Self { data: rom }
     }
 
+    pub fn new_with_data(data: Vec<u8>) -> Rom {
+        Rom { data }
+    }
+
     /// Load `size`-bit data from the memory.
     pub fn read(&self, addr: u64, size: u8) -> Result<u64, Exception> {
         match size {


### PR DESCRIPTION
This PR allows external access to the `Rom` structure so it can be changed. My use case for this is running small bits of RV32i code for testing an assembler. 

Simply placing the RV32i code in the DRAM works in theory, but breaks down with the following instructions (which occur in an RV32i function epilogue):

````
lw ra, sp(0) (load return address from stack)
jalr x0, ra(0) (="ret")
````

In RV32i, the `lw` simply fills the full `ra` register, but in RV64i, `lw` sign-extends the loaded value. Because the upper bit is set (because `DRAM_BASE` is `0x8000_0000`), the return address now also has its upper 32 bits set (`0xffff_ffff_8000_xxxx` but it should be `0x8000_xxxx` on RV32i and `0x0000_0000_8000_xxxx` on RV64i would work), which makes the jump fail (and unfortunately there is not really a way to unset these bits using just RV32i instructions!). 

I tried changing DRAM_BASE to e.g. `0x2000_0000` but it makes several tests fail. Adding the ability to configure DRAM_BASE would be very useful (as would a fully configurable `Bus` - I don't need the interrupt controller, block device, etc.), but for now this workaround fulfills my needs. For now I simply use:

````rust
emu.cpu.bus.rom = Rom::new_with_data(program.to_vec());
emu.initialize_pc(MROM_BASE);
````

